### PR TITLE
Fix exception on launch (with GTK 4.0 installed)

### DIFF
--- a/switcher.py
+++ b/switcher.py
@@ -6,6 +6,9 @@
 # @copyright Oktay Acikalin
 # @license   MIT (LICENSE.txt)
 
+import gi
+gi.require_version('Gtk', '3.0')
+
 from gi.repository import Gtk, Gio, Gdk, Wnck
 import subprocess
 import sys


### PR DESCRIPTION
Launching on a system with GTK 4.0 installed results in a failure with the following error message:

> gi.RepositoryError: Requiring namespace 'Gtk' version '3.0', but '4.0' is already loaded

This patch explicitly requires GTK version 3.0 before importing it, which appears to resolve the issue.

